### PR TITLE
Improved memory usage for state management

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -13,7 +13,9 @@ class State extends Component {
     super(props, context)
     this.broadcast = context.__statty__.broadcast
     this.inspect = context.__statty__.inspect
-    this.state = props.state ? props.state : this.broadcast.getState()
+    this.state = props.state
+      ? props.state
+      : props.select(this.broadcast.getState())
     this.update = this.update.bind(this)
     this.setStateIfNeeded = this.setStateIfNeeded.bind(this)
     this.isUpdating = false

--- a/src/state.js
+++ b/src/state.js
@@ -13,7 +13,6 @@ class State extends Component {
     super(props, context)
     this.broadcast = context.__statty__.broadcast
     this.inspect = context.__statty__.inspect
-    this.prevState = this.broadcast.getState()
     this.state = props.state ? props.state : this.broadcast.getState()
     this.update = this.update.bind(this)
     this.setStateIfNeeded = this.setStateIfNeeded.bind(this)
@@ -37,14 +36,13 @@ class State extends Component {
   }
 
   setStateIfNeeded (nextState) {
-    const oldSelectdedState = this.props.select(this.prevState)
+    const oldSelectdedState = this.state
     const newSelectedState = this.props.select(nextState)
     if (
       !isObjectNotNull(oldSelectdedState, newSelectedState) ||
       !shallowEqual(oldSelectdedState, newSelectedState)
     ) {
-      this.prevState = this.broadcast.getState()
-      this.setState(nextState)
+      this.setState(newSelectedState)
     }
   }
 


### PR DESCRIPTION
I've removed the previousState variable because it was duplicating the memory usage for each Statty component mounted. Also i've changed the state of the component from the global state of broadcast to use only the selected state needed from the selected prop.